### PR TITLE
Add provisioner

### DIFF
--- a/cinder/demo.yaml
+++ b/cinder/demo.yaml
@@ -23,7 +23,7 @@ spec:
       initContainers:
       - name: init
         image: rmohr/cinder-ceph-demo
-        command: "cp /data/scripts/* /scripts/ && cp /data/etc/* /etc/cinder/"
+        command: ["/bin/bash", "-c", "cp -v /data/scripts/* /scripts/ && cp /data/etc/* /etc/cinder/"]
         volumeMounts:
         - name: scripts
           mountPath: "/scripts"
@@ -31,7 +31,7 @@ spec:
           mountPath: "/etc/cinder"
       containers:
       - name: kraken
-        command: "/scripts/ceph-entrypoint.sh demo"
+        command: ["/scripts/ceph-entrypoint.sh", "demo"]
         env:
         - name: CEPH_DEMO_UID
           value: "kubevirt"
@@ -70,7 +70,7 @@ spec:
         image: rabbitmq
       - name: cinder-api
         image: rmohr/cinder:ocata
-        command: "sh /scripts/cinder-api.sh"
+        command: ["/scripts/cinder-api.sh"]
         env:
         - name: INIT_DB
           value: "true"
@@ -81,13 +81,13 @@ spec:
           mountPath: "/etc/cinder"
       - name: cinder-scheduler
         image: rmohr/cinder:ocata
-        command: cinder-scheduler
+        command: ["cinder-scheduler"]
         volumeMounts:
         - name: cinderetc
           mountPath: "/etc/cinder"
       - name: cinder-volume
         image: rmohr/cinder:ocata
-        command: "sh /scripts/ceph-service.sh"
+        command: ["/scripts/ceph-service.sh"]
         env:
         - name: MON_IP
           valueFrom:

--- a/cinder/demo.yaml
+++ b/cinder/demo.yaml
@@ -49,6 +49,8 @@ spec:
           value: "0.0.0.0/0"
         image: ceph/demo
         volumeMounts:
+        - name: scripts
+          mountPath: "/scripts"
         - name: cephvarlib
           mountPath: /var/lib/ceph
         - name: cephetc

--- a/cinder/demo.yaml
+++ b/cinder/demo.yaml
@@ -125,3 +125,11 @@ apiVersion: storage.k8s.io/v1beta1
 metadata:
   name: standalone-cinder
 provisioner: openstack.org/standalone-cinder
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: standalone-cinder-cephx-secret
+type: "kubernetes.io/rbd"
+data:
+  key: QVFDMkI0SmE2MDgzT3hBQTdOR0dpb0xpR1lqOHlJTFpkYUI1T0E9PQo=

--- a/cinder/demo.yaml
+++ b/cinder/demo.yaml
@@ -8,13 +8,13 @@ metadata:
 spec:
   selector:
     matchLabels:
-      name: kubevirt.io/ceph
-    replicas: 1
-    serviceName: "ceph"
+      name: io.kubevirt.ceph-demo
+  replicas: 1
+  serviceName: "ceph"
   template:
     metadata:
       labels:
-        name: kubevirt.io/ceph
+        name: io.kubevirt.ceph-demo
         kubevirt.io: ""
     spec:
       nodeSelector:

--- a/cinder/demo.yaml
+++ b/cinder/demo.yaml
@@ -103,6 +103,11 @@ spec:
           mountPath: "/etc/cinder"
         - name: cephetc
           mountPath: "/etc/ceph"
+      - name: cinder-provisioner
+        image: quay.io/aglitke/standalone-cinder-provisioner:latest
+        env:
+        - name: OS_CINDER_ENDPOINT
+          value: http://127.0.0.1:8776/v3
       volumes:
       - name: scripts 
         emptyDir: {}
@@ -114,3 +119,9 @@ spec:
         emptyDir: {}
       - name: mariadbdata
         emptyDir: {}
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: standalone-cinder
+provisioner: openstack.org/standalone-cinder

--- a/cinder/demo.yaml
+++ b/cinder/demo.yaml
@@ -65,6 +65,7 @@ spec:
           value: "cinder"
         - name: MYSQL_PASSWORD
           value: "password"
+        image: mariadb
         volumeMounts:
         - name: mariadbdata
           mountPath: "/var/lib/mysql"

--- a/cinder/demo.yaml
+++ b/cinder/demo.yaml
@@ -19,6 +19,7 @@ spec:
     spec:
       nodeSelector:
           "kubernetes.io/hostname": "master"
+      hostNetwork: true
       initContainers:
       - name: init
         image: rmohr/cinder-ceph-demo

--- a/cinder/etc/ceph.client.cinder.keyring.in
+++ b/cinder/etc/ceph.client.cinder.keyring.in
@@ -1,0 +1,2 @@
+[client.cinder]
+    key = AQC2B4Ja6083OxAA7NGGioLiGYj8yILZdaB5OA==

--- a/cinder/etc/ceph.conf.in
+++ b/cinder/etc/ceph.conf.in
@@ -3,7 +3,4 @@ mon host = {{ MON_IP }}
 auth cluster required = cephx
 auth service required = cephx
 auth client required = cephx
-keyring = /etc/ceph/ceph.client.admin.keyring
-
-[client.images]
-keyring = /etc/ceph/ceph.client.admin.keyring
+keyring = /etc/ceph/ceph.client.cinder.keyring

--- a/cinder/etc/cinder-client.rc
+++ b/cinder/etc/cinder-client.rc
@@ -1,5 +1,5 @@
 export OS_AUTH_SYSTEM=noauth
 export CINDER_ENDPOINT=http://127.0.0.1:8776/v3
-export OS_PROJECT_ID=myproject
+export OS_TENANT_ID=admin
 export OS_USERNAME=bubba
 export OS_VOLUME_API_VERSION=3.27

--- a/cinder/etc/cinder.conf
+++ b/cinder/etc/cinder.conf
@@ -26,4 +26,4 @@ rbd_max_clone_depth = 5
 rbd_store_chunk_size = 4
 rados_connect_timeout = -1
 glance_api_version = 2
-rbd_user = admin
+rbd_user = cinder

--- a/cinder/scripts/ceph-service.sh
+++ b/cinder/scripts/ceph-service.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-yum -y install python-rbd python-rados iproute
+yum -y install python-rbd python-rados iproute ceph-common
 
 if [[ -z "$MON_IP" ]]; then
   MON_IP=$(ip -o -4 a | tr -s ' ' | grep -v -e ' lo[0-9:]*.*$' | cut -d' ' -f 4  | head -1 | sed "s#/.*##")

--- a/cinder/scripts/ceph-service.sh
+++ b/cinder/scripts/ceph-service.sh
@@ -21,4 +21,12 @@ do
   sleep 2
 done
 
+
+# Import the cinder user.  This gives us a known key so we can use it also in
+# a kubernetes secret.
+ceph auth import -i /etc/cinder/ceph.client.cinder.keyring.in
+ceph auth caps client.cinder mon 'allow r' osd 'allow class-read object_prefix rdb_children, allow rwx pool=images'
+cp /etc/cinder/ceph.client.cinder.keyring.in /etc/ceph/ceph.client.cinder.keyring
+
+
 cinder-volume -d


### PR DESCRIPTION
This PR adds automatic support for the dynamic provisioner.  You can create PVCs and they will be dynamically bound to ceph volumes.  You cannot use the pvcs with pods yet due to a possible bug with the provisioner.
