### PR TITLE
example: Add four part tinycore example

### DIFF
--- a/examples/tinycore-demo-01-base-pvc.yaml
+++ b/examples/tinycore-demo-01-base-pvc.yaml
@@ -1,0 +1,12 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: tinycore
+spec:
+  storageClassName: standalone-cinder
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/examples/tinycore-demo-02-import-disk.yaml
+++ b/examples/tinycore-demo-02-import-disk.yaml
@@ -1,0 +1,24 @@
+---
+Version: v1
+kind: Pod
+metadata:
+  name: disk-importer
+spec:
+  restartPolicy: OnFailure
+  containers:
+  - name: importer
+    image: kubevirtci/disk-importer
+    env:
+      - name: CURL_OPTS
+        value: "-L"
+      - name: INSTALL_TO
+        value: /storage/disk.img
+      - name: URL
+        value: http://distro.ibiblio.org/tinycorelinux/8.x/x86/release/TinyCore-current.iso
+    volumeMounts:
+    - name: ceph-storage
+      mountPath: /storage
+  volumes:
+  - name: ceph-storage
+    persistentVolumeClaim:
+      claimName: tinycore

--- a/examples/tinycore-demo-03-clone-pvc.yaml
+++ b/examples/tinycore-demo-03-clone-pvc.yaml
@@ -1,0 +1,14 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: demo-vm-tinycore
+  annotations:
+    k8s.io/CloneRequest: tinycore
+spec:
+  storageClassName: standalone-cinder
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/examples/tinycore-demo-04-run-vm.yaml
+++ b/examples/tinycore-demo-04-run-vm.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kubevirt.io/v1alpha1
+kind: VirtualMachine
+metadata:
+  name: demo-vm
+spec:
+  terminationGracePeriodSeconds: 0
+  domain:
+    resources:
+      requests:
+        memory: 64M
+    devices:
+      disks:
+      - name: mydisk
+        volumeName: pvcvolume
+        disk:
+          dev: vda
+  volumes:
+    - name: pvcvolume
+      persistentVolumeClaim:
+        claimName: demo-vm-tinycore


### PR DESCRIPTION
Add example yaml files to run a tinycore vm.  The 4 files implement the
following steps:
 1. Create base pvc to hold imported tinycore disk
 2. Import tinycore disk
 3. Clone tinycore pvc to a new pvc to use with vm
 4. Launch vm

To work around an issue in kubernetes, it is recommended to wait 15
seconds after creating a pvc before moving on to the next step.
Otherwise a delay of up to 4 minutes is possible when starting the pod.

Signed-off-by: Adam Litke <alitke@redhat.com>