### PR TITLE
Add explicit node label for storage

### DIFF
--- a/master/templates/inventory
+++ b/master/templates/inventory
@@ -39,6 +39,9 @@ openshift_hosted_etcd_storage_labels={'storage': 'etcd'}
 {% endfor %}
 
 [nodes]
-{% for host in groups['all'] %}
+{% for host in groups['master'] %}
+{{ host }} openshift_node_labels="{'region': 'infra','zone': 'default', 'storage': 'yes'}" openshift_schedulable=true openshift_ip={{ hostvars[host].ansible_host }}
+{% endfor %}
+{% for host in groups['nodes'] %}
 {{ host }} openshift_node_labels="{'region': 'infra','zone': 'default'}" openshift_schedulable=true openshift_ip={{ hostvars[host].ansible_host }}
 {% endfor %}

--- a/storage/templates/provisioner.yaml
+++ b/storage/templates/provisioner.yaml
@@ -43,7 +43,7 @@ spec:
         type: RollingUpdate
       serviceAccountName: provisioner
       nodeSelector:
-          "kubernetes.io/hostname": "{{ inventory_hostname }}"
+          "storage": "yes"
       hostNetwork: true
       containers:
       - name: kraken


### PR DESCRIPTION
Add an explicit label to one node to make the need to always schedule a
pod on the same node more obvious.

This is part of the preparation for a re-deployable storage
configuration. It is right now already restartable.

Signed-off-by: Roman Mohr <rmohr@redhat.com>