### PR TITLE
Update README with correct VM name

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ $ ./oc.sh get vms -o yaml | grep phase
 To connect to a VM:
 
 ```bash
-./oc.sh console demo-vm  # Serial console
-./oc.sh vnc demo-vm      # VNC
+./oc.sh console testvm-ephemeral  # Serial console
+./oc.sh vnc testvm-ephemeral      # VNC
 ```
 
 To import and run a cirros vm:


### PR DESCRIPTION
The vm created in vn.yaml is called testvm-ephemeral instead of
demo-vm.